### PR TITLE
add name and version so it can be installed with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "wait-for",
+  "version": "0.1.0",
   "scripts": {
     "test": "./node_modules/.bin/bats wait-for.bats"
   },


### PR DESCRIPTION
as is it won't install with npm (at least not with version 5.3.0) due to these error messages:

`Missing package name`
`Missing package version`

so adding these to fix that