### PR TITLE
Make docker build produce a runnable wait-for image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:alpine
-
-RUN apk add --no-cache bash
-
-RUN mkdir -p /app
+FROM node:alpine as test-env
+RUN apk add --no-cache bash && mkdir -p /app
 WORKDIR /app
-
 COPY . /app
-RUN npm install
+RUN npm install && npm run test
 
-CMD ./node_modules/.bin/bats wait-for.bats
+FROM alpine:edge
+RUN apk add --no-cache curl
+ENTRYPOINT ["/wait-for"]
+CMD ["--help"]
+COPY --from=test-env /app/wait-for /wait-for

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "scripts": {
-    "test": "./node_modules/.bin/bats wait-for.bats"
+    "test": "bats wait-for.bats"
   },
   "dependencies": {
     "bats": "^0.4.2"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
This change adds a [multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) so that the resulting Docker image is a suitable base for a runtime container. It would be nice if you could add an automated build on the Docker Hub.
