### PR TITLE
use 'exec "$@"'

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -20,14 +20,13 @@ USAGE
 }
 
 wait_for() {
-  command="$*"
   for i in `seq $TIMEOUT` ; do
     nc -z "$HOST" "$PORT" > /dev/null 2>&1
     
     result=$?
     if [ $result -eq 0 ] ; then
-      if [ -n "$command" ] ; then
-        exec $command
+      if [ $# -gt 0 ] ; then
+        exec "$@"
       fi
       exit 0
     fi


### PR DESCRIPTION
I use waitfor command with argument which contains white space like:

`waitfor localhost:80 -- some-command "a b c"`

"a b c" is split into 3 arguments a, b, c, not "a b c".

This PR fixes this problem.
