### PR TITLE
preserve existing environment variable

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -20,12 +20,20 @@ USAGE
 }
 
 wait_for() {
+  _HOST=$HOST
+  _PORT=$PORT
   for i in `seq $TIMEOUT` ; do
     nc -z "$HOST" "$PORT" > /dev/null 2>&1
-    
+
     result=$?
     if [ $result -eq 0 ] ; then
       if [ $# -gt 0 ] ; then
+        unset HOST
+        unset PORT
+        HOST=$_HOST
+        PORT=$_PORT
+        unset _HOST
+        unset _PORT
         exec "$@"
       fi
       exit 0

--- a/wait-for.bats
+++ b/wait-for.bats
@@ -2,7 +2,7 @@
 
 @test "google should be immediately found" {
   run ./wait-for google.com:80 -- echo 'success'
-  
+
   [ "$output" = "success" ]
 }
 
@@ -11,4 +11,13 @@
 
   [ "$status" -ne 0 ]
   [ "$output" != "success" ]
+}
+
+@test "preserve existing environment variable" {
+  HOST=myweb.com
+  PORT=8080
+  run ./wait-for google.com:80 -- echo 'success'
+
+  [ "$(echo $HOST)" = 'myweb.com' ]
+  [ "$(echo $PORT)" = '8080' ]
 }


### PR DESCRIPTION
Previously wait-for create or override $HOST and $PORT environment variables, this PR preserve existing variables and restore their value when wait-for finish.