### PR TITLE
Fix the silent timeout error when netcat is not installed

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -3,6 +3,11 @@
 TIMEOUT=15
 QUIET=0
 
+if ! which nc >/dev/null; then
+  echo "Netcat is not installed. This script requires netcat to work correctly."
+  exit 1
+fi
+
 echoerr() {
   if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
 }


### PR DESCRIPTION
Fixes silent timeouts on containers without `netcat`, such as the [official CentOS docker image](https://hub.docker.com/_/centos/).