### PR TITLE
Prefix ENV variables to avoid clashes

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-TIMEOUT=15
-QUIET=0
+WAITFOR_TIMEOUT=15
+WAITFOR_QUIET=0
 
 echoerr() {
-  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+  if [ "$WAITFOR_QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
 }
 
 usage() {
@@ -20,9 +20,9 @@ USAGE
 }
 
 wait_for() {
-  for i in `seq $TIMEOUT` ; do
-    nc -z "$HOST" "$PORT" > /dev/null 2>&1
-    
+  for i in `seq $WAITFOR_TIMEOUT` ; do
+    nc -z "$WAITFOR_HOST" "$WAITFOR_PORT" > /dev/null 2>&1
+
     result=$?
     if [ $result -eq 0 ] ; then
       if [ $# -gt 0 ] ; then
@@ -40,21 +40,21 @@ while [ $# -gt 0 ]
 do
   case "$1" in
     *:* )
-    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
-    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    WAITFOR_HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    WAITFOR_PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
     shift 1
     ;;
     -q | --quiet)
-    QUIET=1
+    WAITFOR_QUIET=1
     shift 1
     ;;
     -t)
-    TIMEOUT="$2"
-    if [ "$TIMEOUT" = "" ]; then break; fi
+    WAITFOR_TIMEOUT="$2"
+    if [ "$WAITFOR_TIMEOUT" = "" ]; then break; fi
     shift 2
     ;;
     --timeout=*)
-    TIMEOUT="${1#*=}"
+    WAITFOR_TIMEOUT="${1#*=}"
     shift 1
     ;;
     --)
@@ -71,7 +71,7 @@ do
   esac
 done
 
-if [ "$HOST" = "" -o "$PORT" = "" ]; then
+if [ "$WAITFOR_HOST" = "" -o "$WAITFOR_PORT" = "" ]; then
   echoerr "Error: you need to provide a host and port to test."
   usage 2
 fi


### PR DESCRIPTION
When using `HOST` and  `PORT` env variables, they were clashing with my `puma`. It might be good to prefix the env variables.