### PR TITLE
Add support for HTTP status check with wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 
 When using this tool, you only need to pick the `wait-for` file as part of your project.
 
+It uses `netcat` for testing ports, and `wget` for HTTP status.
+
 [![Build Status](https://travis-ci.org/eficode/wait-for.svg?branch=master)](https://travis-ci.org/eficode/wait-for)
 
 ## Usage
 
 ```
-./wait-for host:port [-t timeout] [-- command args]
+./wait-for host:port|url [-t timeout] [-- command args]
   -q | --quiet                        Do not output any status messages
   -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
   -- COMMAND ARGS                     Execute command with args after the test finishes
@@ -24,12 +26,14 @@ $ ./wait-for www.eficode.com:80 -- echo "Eficode site is up"
 
 Connection to www.eficode.com port 80 [tcp/http] succeeded!
 Eficode site is up
+
+$ ./wait-for http://www.eficode.com:80/ping -- echo "Eficode site is up"
 ```
 
 To wait for database container to become available:
 
 
-```
+```yml
 version: '2'
 
 services:
@@ -41,6 +45,27 @@ services:
     command: sh -c './wait-for db:5432 -- npm start'
     depends_on:
       - db
+```
+
+To wait for your API service to become available:
+
+
+```yml
+version: '2'
+
+services:
+  db:
+    image: postgres:9.4
+
+  api:
+    image: my_awesome_api
+
+  tests:
+    build: tests
+    command: sh -c './wait-for http://api/ping -- jest test'
+    depends_on:
+      - db
+      - api
 ```
 
 ## Testing

--- a/wait-for
+++ b/wait-for
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-TIMEOUT=15
+TIMEOUT=150
 QUIET=0
+WAITFOR_RETRY_DELAY=0.1
 
 echoerr() {
   if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
@@ -11,7 +12,7 @@ usage() {
   exitcode="$1"
   cat << USAGE >&2
 Usage:
-  $cmdname host:port [-t timeout] [-- command args]
+  $cmdname host:port|url [-t timeout] [-- command args]
   -q | --quiet                        Do not output any status messages
   -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
   -- COMMAND ARGS                     Execute command with args after the test finishes
@@ -22,7 +23,7 @@ USAGE
 wait_for() {
   for i in `seq $TIMEOUT` ; do
     nc -z "$HOST" "$PORT" > /dev/null 2>&1
-    
+
     result=$?
     if [ $result -eq 0 ] ; then
       if [ $# -gt 0 ] ; then
@@ -30,7 +31,24 @@ wait_for() {
       fi
       exit 0
     fi
-    sleep 1
+    sleep $WAITFOR_RETRY_DELAY
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+wait_for_http() {
+  for i in `seq $TIMEOUT` ; do
+    wget --timeout=1 -q "$WAITFOR_URL" -O /dev/null > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep $WAITFOR_RETRY_DELAY
   done
   echo "Operation timed out" >&2
   exit 1
@@ -39,6 +57,10 @@ wait_for() {
 while [ $# -gt 0 ]
 do
   case "$1" in
+    http*)
+    WAITFOR_URL=$1
+    shift 1
+    ;;
     *:* )
     HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
     PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
@@ -71,9 +93,13 @@ do
   esac
 done
 
-if [ "$HOST" = "" -o "$PORT" = "" ]; then
-  echoerr "Error: you need to provide a host and port to test."
+if [ "$HOST" = "" -o "$PORT" = "" ] && [ "$WAITFOR_URL" = "" ]; then
+  echoerr "Error: you need to provide a host and port OR an URL to test."
   usage 2
 fi
 
-wait_for "$@"
+if [ "$WAITFOR_URL" != "" ]; then
+  wait_for_http "$@"
+else
+  wait_for "$@"
+fi

--- a/wait-for.bats
+++ b/wait-for.bats
@@ -2,12 +2,32 @@
 
 @test "google should be immediately found" {
   run ./wait-for google.com:80 -- echo 'success'
-  
+
+  [ "$output" = "success" ]
+}
+
+@test "https://duckduckgo.com should be immediately found" {
+  run ./wait-for https://duckduckgo.com -- echo 'success'
+
   [ "$output" = "success" ]
 }
 
 @test "nonexistent server should not start command" {
   run ./wait-for -t 1 noserver:9999 -- echo 'success'
+
+  [ "$status" -ne 0 ]
+  [ "$output" != "success" ]
+}
+
+@test "connection error in HTTP test should not start command" {
+  run ./wait-for -t 1 http://google.com:8080 -- echo 'success'
+
+  [ "$status" -ne 0 ]
+  [ "$output" != "success" ]
+}
+
+@test "not found HTTP status should not start command" {
+  run ./wait-for -t 1 http://google.com/ping -- echo 'success'
 
   [ "$status" -ne 0 ]
   [ "$output" != "success" ]


### PR DESCRIPTION
Add support for HTTP status check with `wget`, shipped with Alpine through busybox.

Test if an API is up:
`./wait-for http://www.eficode.com:80/ping -- echo "Eficode site is up"`

Within a `docker-compose` file:
```yml
version: '2'

services:
  db:
    image: postgres:9.4

  api:
    image: my_awesome_api

  tests:
    build: tests
    command: sh -c './wait-for http://api/ping -- jest test'
    depends_on:
      - db
      - api
```
