### PR TITLE
add bats testrunner only as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "test": "./node_modules/.bin/bats wait-for.bats"
   },
-  "dependencies": {
+  "devDependencies": {
     "bats": "^0.4.2"
   }
 }


### PR DESCRIPTION
reduces size of npm_modules *drastically* (⸮) by ~60kb when added to a project via npm