### PR TITLE
Add check for netcat

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -71,6 +71,12 @@ do
   esac
 done
 
+
+if ! type "nc" > /dev/null; then
+    echo "Error: netcat is required for wait-for to run." >&2
+    exit 1
+fi
+
 if [ "$HOST" = "" -o "$PORT" = "" ]; then
   echoerr "Error: you need to provide a host and port to test."
   usage 2


### PR DESCRIPTION
Without netcat install the wait-for script simply times out and it is confusing whether the timeout is due to lack of netcat or because the port didn't come up. Adding this check prevents wait-for script from coming up when netcat isn't installed.