### PR TITLE
[enhancement] Exit with error message if netcat is not installed

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -20,9 +20,10 @@ USAGE
 }
 
 wait_for() {
+  type nc > /dev/null 2>&1 || { echo >&2 "wait-for requires nc to be installed.  Aborting."; exit 1; }
   for i in `seq $TIMEOUT` ; do
     nc -z "$HOST" "$PORT" > /dev/null 2>&1
-    
+
     result=$?
     if [ $result -eq 0 ] ; then
       if [ $# -gt 0 ] ; then


### PR DESCRIPTION
# What
This PR adds a check whether netcat is installed and if not, exits with an error message

# How
I simply use `type`

# Why
I was experiencing odd timeout behaviour in a lean docker container and discovered this was due to the fact that netcat wasn't installed and all output of `nc -z` is piped to `/dev/null`. 