### PR TITLE
Add check if nc is present

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -20,6 +20,11 @@ USAGE
 }
 
 wait_for() {
+ if ! command -v nc >/dev/null; then
+    echoerr 'nc command is missing!'
+    exit 1
+  fi
+
   for i in `seq $TIMEOUT` ; do
     nc -z "$HOST" "$PORT" > /dev/null 2>&1
     


### PR DESCRIPTION
If nc was not installed, wait-for script failed without any error message which is suboptimal. Therefore this commit adds check for nc and prints appropriate error message if not found.