### PR TITLE
build(npm): checks in dependency lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "wait-for",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bats": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-0.4.2.tgz",
+      "integrity": "sha1-gfIiu8uwg9FSiz6IMKbo8xSHbsY=",
+      "dev": true
+    }
+  }
+}


### PR DESCRIPTION
Gives better control over which version of Bats is installed.