### PR TITLE
fix(iteration): Pointless waiting before a known timeout

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -59,9 +59,24 @@ do
     QUIET=1
     shift 1
     ;;
-    -t)
+    -q-*)
+    QUIET=0
+    echoerr "Unknown option: $1"
+    usage 1
+    ;;
+    -q*)
+    QUIET=1
+    result=$1
+    shift 1
+    set -- -"${result#-q}" "$@"
+    ;;
+    -t | --timeout)
     TIMEOUT="$2"
     shift 2
+    ;;
+    -t*)
+    TIMEOUT="${1#-t}"
+    shift 1
     ;;
     --timeout=*)
     TIMEOUT="${1#*=}"
@@ -74,7 +89,13 @@ do
     --help)
     usage 0
     ;;
+    -*)
+    QUIET=0
+    echoerr "Unknown option: $1"
+    usage 1
+    ;;
     *)
+    QUIET=0
     echoerr "Unknown argument: $1"
     usage 1
     ;;

--- a/wait-for
+++ b/wait-for
@@ -55,7 +55,6 @@ do
     ;;
     -t)
     TIMEOUT="$2"
-    if [ "$TIMEOUT" = "" ]; then break; fi
     shift 2
     ;;
     --timeout=*)
@@ -75,6 +74,11 @@ do
     ;;
   esac
 done
+
+if ! [ "$TIMEOUT" -ge 0 ] 2>/dev/null; then
+  echoerr "Error: invalid timeout '$TIMEOUT'"
+  usage 3
+fi
 
 if [ "$HOST" = "" -o "$PORT" = "" ]; then
   echoerr "Error: you need to provide a host and port to test."

--- a/wait-for
+++ b/wait-for
@@ -25,7 +25,7 @@ wait_for() {
     exit 1
   fi
 
-  for i in `seq $TIMEOUT` ; do
+  while :; do
     nc -z "$HOST" "$PORT" > /dev/null 2>&1
     
     result=$?
@@ -35,6 +35,12 @@ wait_for() {
       fi
       exit 0
     fi
+
+    if [ "$TIMEOUT" -le 0 ]; then
+      break
+    fi
+    TIMEOUT=$((TIMEOUT - 1))
+
     sleep 1
   done
   echo "Operation timed out" >&2

--- a/wait-for.bats
+++ b/wait-for.bats
@@ -12,3 +12,23 @@
   [ "$status" -ne 0 ]
   [ "$output" != "success" ]
 }
+
+@test "support condensed option style" {
+  run ./wait-for -qt1 google.com:80 -- echo 'success'
+
+  [ "$output" = "success" ]
+}
+
+@test "timeout cannot be negative" {
+  run ./wait-for -t -1 google.com:80 -- echo 'success'
+
+  [ "$status" -ne 0 ]
+  [ "$output" != "success" ]
+}
+
+@test "timeout cannot be empty" {
+  run ./wait-for -t -- google.com:80 -- echo 'success'
+
+  [ "$status" -ne 0 ]
+  [ "$output" != "success" ]
+}


### PR DESCRIPTION
Every time a timeout occurs, there is one second consumed for nothing.

## Illustration
```sh
$ sed <wait-for 's/nc -/echo Attempt!;&/;s/sleep /echo Wait...;&/' | sh -s -- -t 3 intended.to.be.invalid:80
Attempt!
Wait...
Attempt!
Wait...
Attempt!
Wait...
Operation timed out
```

Since there is no attempt made after the third waiting, the outcome of such 3-seconds execution depends entirely on the first three attempts. And a known failure is always projected to one second later into the future, despite the insignificance of further waiting.

With 23bbf6d, there will be a fourth attempt:

```sh
$ sed <wait-for 's/nc -/echo Attempt!;&/;s/sleep /echo Wait...;&/' | sh -s -- -t 3 intended.to.be.invalid:80
Attempt!
Wait...
Attempt!
Wait...
Attempt!
Wait...
Attempt!
Operation timed out
```

It is more natural to use TIMEOUT + 1 as the maximum number of attempts.

## Other changes
### 22d68b4 - feat(option): Restrict the timeout input to non-negative integers
```sh
$ ./wait-for -t -1 google.com:80 2>&1 | head -n1
Error: invalid timeout '-1'
$ ./wait-for -t -- google.com:80 2>&1 | head -n1
Error: invalid timeout '--'
```
### 526918b - feat(option): Support more conventional formats in the option parser
```
$ time ./wait-for -qt3 intended.to.be.invalid:80
Operation timed out
Command exited with non-zero status 1
real    0m 3.03s
user    0m 0.00s
sys     0m 0.01s
```
This is what I created this PR for in the first place.
### 9964904 - fix(command): Restore environment variables before calling `exec`
```
$ PORT=3000 ./wait-for -t0 google.com:80 -- sh -c 'echo "$PORT"'
3000
$ ./wait-for -t0 google.com:80 -- sh -uc 'echo "$PORT"'
sh: PORT: parameter not set
```
By using positional parameters, we avoid transferring the problem endlessly to other variables:
```sh
set -- "$@" -- "$TIMEOUT" "$QUIET" "$HOST" "$PORT" "$result"
```
