### PR TITLE
ci(release): adds wait-for script as a GitHub release asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,18 @@
         }
       ],
       "@semantic-release/git",
-      "@semantic-release/github"
+      [
+        "@semantic-release/github",
+        {
+          "assets": [
+            { 
+              "path": "wait-for", 
+              "name": "wait-for_${nextRelease.gitTag}", 
+              "label": "The wait-for script (${nextRelease.gitTag})"
+            }
+          ]
+        }
+      ]
     ]
   }
 }


### PR DESCRIPTION
This change let's `semantic-release` automatically add the `wait-for` script as a release asset, which makes it easier to download a specific version.