### PR TITLE
fix(timeout): resolve degredation which prevented setting indefinite timeout

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -96,7 +96,7 @@ wait_for() {
       exit 0
     fi
 
-    if [ $(date +%s) -ge $TIMEOUT_END ]; then
+    if [ $TIMEOUT -ne 0 -a $(date +%s) -ge $TIMEOUT_END ]; then
       echo "Operation timed out" >&2
       exit 1
     fi

--- a/wait-for.bats
+++ b/wait-for.bats
@@ -33,6 +33,29 @@
   [ "$output" != "success" ]
 }
 
+@test "wget timeout zero does not immediately timeout" {
+  # Arrange
+  timeout=0  # The timeout we will use to invoke the wait-for command with
+  delay=5  # The amount of seconds to wait to see if our indefinite timeout works
+
+  # Act
+  # - Invoke non-existing local webserver and record duration
+  start_time=$(date +%s)
+  run timeout $delay ./wait-for -t ${timeout} http://localhost/
+  end_time=$(date +%s)
+
+  # Assert
+  # - Assert that the script should't have printed that it timed-out
+  [ "$output" != "Operation timed out" ]
+
+  # - Expect a non-zero exit code
+  [ "$status" != 0 ]
+
+  # - Assert that wait-for waited at least as long as we we're going to test delaying for. 
+  elapsed=$((end_time - start_time))
+  [ ${elapsed} -ge ${delay} ]
+}
+
 @test "wget timeout does not double" {
   timeout=10
   cat >delay <<-EOF


### PR DESCRIPTION
The help text suggests that one should be able to configure an indefinite timeout by setting it to zero. However, the current implementation would immediately timeout while doing so.

This change ignores the timeout behaviour when the timeout argument is set to 0. In addition, a test is added which tests whether the timeout at least doesn't immediately time out.

Resolves the issue mentioned here https://github.com/eficode/wait-for/pull/72#discussion_r789442709.