### PR TITLE
chore(npm): adds test:docker command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "wait-for",
   "version": "2.2.1",
   "scripts": {
-    "test": "./node_modules/.bin/bats wait-for.bats"
+    "test": "./node_modules/.bin/bats wait-for.bats",
+    "test:docker": "docker build -t wait-for-test . && docker run --rm -it wait-for-test"
   },
   "devDependencies": {
     "@google/semantic-release-replace-plugin": "^1.1.0",


### PR DESCRIPTION
Allows running `npm run test:docker` to run the test-suite in Docker.
