### PR TITLE
Fix protocol check for wget availability

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -55,7 +55,7 @@ wait_for() {
         exit 1
       fi
       ;;
-    wget)
+    http)
       if ! command -v wget >/dev/null; then
         echoerr 'wget command is missing!'
         exit 1


### PR DESCRIPTION
`$PROTOCOL` will either be `tcp` (the default) or `http` (set when `$HOST` starts with http or https).

Previously the value `wget` was being checked against, but it should be `http` as that's the value `PROTOCOL` will be when `wget` is necessary.