### PR TITLE
ci: configures timeout for test and release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v3
@@ -20,6 +21,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
 
     needs:
       - test


### PR DESCRIPTION
Prevents extremely long CI runs in cases where e.g. the tests are stuck.
