### PR TITLE
ci(release): enables concurrency limit for release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
 
+    # Prevents running multiple release scripts at the same time
+    concurrency: 'release'
+
     needs:
       - test
 


### PR DESCRIPTION
Running the release job in parallel can potentially cause issues, e.g. by exhausting ratelimits against the GH API.
