### PR TITLE
wget in alpine runs into an endless retry loop

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -68,11 +68,11 @@ wait_for() {
 
   while :; do
     case "$PROTOCOL" in
-      tcp) 
+      tcp)
         nc -w 1 -z "$HOST" "$PORT" > /dev/null 2>&1
         ;;
       http)
-        wget --timeout=1 -q "$HOST" -O /dev/null > /dev/null 2>&1 
+        wget --timeout=1 --tries=1 -q "$HOST" -O /dev/null > /dev/null 2>&1
         ;;
       *)
         echoerr "Unknown protocol '$PROTOCOL'"
@@ -81,7 +81,7 @@ wait_for() {
     esac
 
     result=$?
-        
+
     if [ $result -eq 0 ] ; then
       if [ $# -gt 7 ] ; then
         for result in $(seq $(($# - 7))); do


### PR DESCRIPTION
The issue appeard in [#2](https://github.com/eficode/wait-for/pull/2#discussion_r1056496970): when running tests in an Alpine based container, the test case `9 wget timeout does not double` hangs due to other defaults and wget endlessly retrying the request (though `wait-for` would like to perform those retries :) ).